### PR TITLE
Fixed detecting of System Registration dialog

### DIFF
--- a/src/rhsm/gui/tasks/tasks.clj
+++ b/src/rhsm/gui/tasks/tasks.clj
@@ -207,7 +207,7 @@
                :name owner
                :msg  (str "Not found in 'Owner Selection':" owner)})
       (ui selectrow :owner-view owner)))
-  (when (ui waittillwindowexist :register-dialog 30)
+  (when (bool (ui waittillwindowexist :register-dialog 30))
     (ui click :register))
   (checkforerror 10))
 


### PR DESCRIPTION
Wrapped the waittillwindowexist inside (bool ) so that it properly detected if the dialog existed or not