### PR TITLE
Ensure that entitlementCertDir is set back

### DIFF
--- a/src/rhsm/gui/tasks/tasks.clj
+++ b/src/rhsm/gui/tasks/tasks.clj
@@ -126,7 +126,8 @@
         (if (and (not result?) force?)
           (do
             (run-command "killall -9 subscription-manager-gui")
-            (ui waittillwindownotexist :main-window 30))))
+            (ui waittillwindownotexist :main-window 30)
+            (run-command "pkill rhsmd"))))
       (sleep 1000))
   ([]
      (if (= "RHEL7" (get-release))

--- a/src/rhsm/gui/tasks/tasks.clj
+++ b/src/rhsm/gui/tasks/tasks.clj
@@ -126,8 +126,7 @@
         (if (and (not result?) force?)
           (do
             (run-command "killall -9 subscription-manager-gui")
-            (ui waittillwindownotexist :main-window 30)
-            (run-command "pkill rhsmd"))))
+            (ui waittillwindownotexist :main-window 30))))
       (sleep 1000))
   ([]
      (if (= "RHEL7" (get-release))

--- a/src/rhsm/gui/tests/import_tests.clj
+++ b/src/rhsm/gui/tests/import_tests.clj
@@ -70,20 +70,24 @@
 (defn setup-entitlement-certs
   "Generates entitlement certs into directory imp-ent-cert-dir"
   [^String imp-ent-cert-dir]
-  (run-command "killall -9 yum")                            ;; prevent yum from blowing up
+  (run-command "killall -9 yum")
+  ;; prevent yum from blowing up
   (safe-delete imp-ent-cert-dir)
   (make-dir imp-ent-cert-dir)
   (let [[user pw org] (for [x [:username :password :owner-key]] (x @config))
-        _ (run-command (format "subscription-manager register --user=%s --password=%s --org=%s" user pw org))
-        orig-ent-cert-dir (tasks/conf-file-value "entitlementCertDir")
-        _ (tasks/set-conf-file-value "entitlementCertDir" imp-ent-cert-dir)
-        pools (random-from-pool (map :id (ctasks/list-available true)) 5)
-        args (apply str " --pool=" (interpose " --pool=" pools))
-        _ (run-command (str "subscription-manager attach " args))]
-    ;; Copy all of the entitlement .pem files to entitle-dir because unregistering deletes the *.pem files
-    (tasks/set-conf-file-value "entitlementCertDir" orig-ent-cert-dir)
-    ;; unregistering will delete all the entitlements, , then restore
-    (run-command "subscription-manager unregister")))
+        orig-ent-cert-dir (tasks/conf-file-value "entitlementCertDir")]
+    (run-command (format "subscription-manager register --user=%s --password=%s --org=%s" user pw org))
+    (try
+      (tasks/set-conf-file-value "entitlementCertDir" imp-ent-cert-dir)
+      (let [pools (random-from-pool (map :id (ctasks/list-available true)) 5)
+            args (apply str " --pool=" (interpose " --pool=" pools))]
+        (run-command (str "subscription-manager attach " args)))
+      (finally
+        (log/info "moving entitlementCertDir back to original state")
+        ;; Copy all of the entitlement .pem files to entitle-dir because unregistering deletes the *.pem files
+        (tasks/set-conf-file-value "entitlementCertDir" orig-ent-cert-dir)
+        ;; unregistering will delete all the entitlements, , then restore
+        (run-command "subscription-manager unregister")))))
 
 (defn make-importable-cert
   "Given a path to entitlement cert, generate an importable cert and store it in import-path"

--- a/src/rhsm/gui/tests/import_tests.clj
+++ b/src/rhsm/gui/tests/import_tests.clj
@@ -87,7 +87,9 @@
         ;; Copy all of the entitlement .pem files to entitle-dir because unregistering deletes the *.pem files
         (tasks/set-conf-file-value "entitlementCertDir" orig-ent-cert-dir)
         ;; unregistering will delete all the entitlements, , then restore
-        (run-command "subscription-manager unregister")))))
+        (run-command "subscription-manager unregister")
+        ;; /usr/libexec/rhsmd remembers an older version of rhsm.conf. So we will reload it.
+        (run-command "pkill rhsmd")))))
 
 (defn make-importable-cert
   "Given a path to entitlement cert, generate an importable cert and store it in import-path"

--- a/test/rhsm/gui/tests/register_test.clj
+++ b/test/rhsm/gui/tests/register_test.clj
@@ -25,14 +25,7 @@
 
 (deftest check_traceback_unregister-test
   (tasks/restart-app)
-  ;(rtests/check_traceback_unregister nil)
-  (case (tt/get-release)
-    "RHEL6"    (rtests/check_traceback_unregister nil)
-    "RHEL7"    (try
-                 (rtests/check_traceback_unregister nil)
-                 (catch java.lang.AssertionError _
-                   (is (= (@c/config :server-hostname) (tasks/conf-file-value "hostname")))))
-    :no-test))
+  (rtests/check_traceback_unregister nil))
 
 (deftest simple-register-test
   (testing "Simple Register Tests"


### PR DESCRIPTION
I have surrounded a code that can raise an exception. I have put a code that set the value to the origin value into finally block.