### PR TITLE
added attr force-kill?

### DIFF
--- a/src/rhsm/gui/tasks/tasks.clj
+++ b/src/rhsm/gui/tasks/tasks.clj
@@ -867,10 +867,12 @@
 (defn restart-app
   "Restarts subscription-manager-gui"
   [& {:keys [unregister?
-             reregister?]
+             reregister?
+             force-kill?]
       :or {unregister? false
-           reregister? false}}]
-  (kill-app)
+           reregister? false
+           force-kill? false}}]
+  (kill-app force-kill?)
   (if (or unregister? reregister?)
     (run-command "subscription-manager unregister"))
   (start-app)

--- a/src/rhsm/gui/tests/register_tests.clj
+++ b/src/rhsm/gui/tests/register_tests.clj
@@ -247,7 +247,7 @@
   (tasks/set-conf-file-value "hostname" (@config :server-hostname))
   (tasks/set-conf-file-value "port" (@config :server-port))
   (tasks/set-conf-file-value "prefix" (@config :server-prefix))
-  (tasks/restart-app))
+  (tasks/restart-app :force-kill? true))
 
 (defn ^{Test {:groups ["registration"
                        "tier1"


### PR DESCRIPTION
There is a problem with test that uses "Default" button - group activation-register. It is necessary to restart app forcing kill. Since a dialog with wrong url can be raisen.