### PR TITLE
fixed bad_proxy test

### DIFF
--- a/src/rhsm/gui/tasks/tasks.clj
+++ b/src/rhsm/gui/tasks/tasks.clj
@@ -58,6 +58,11 @@
   [object]
   (.trim (ui getobjectproperty object "label")))
 
+(defn close-error-dialog
+  []
+  (if (ui guiexist :error-dialog)
+    (ui click :ok-error)))
+
 (defn checkforerror
   "Checks for the error dialog for 3 seconds and logs the error message.
   Allows for recovery of the error message.

--- a/src/rhsm/gui/tests/proxy_tests.clj
+++ b/src/rhsm/gui/tests/proxy_tests.clj
@@ -256,7 +256,8 @@
     (finally
      (if (bool (tasks/ui guiexist :facts-dialog))
        (tasks/ui click :close-facts))
-
+     (if (bool (tasks/ui guiexist :error-dialog))
+       (tasks/ui click :ok-error))
      (disable_proxy nil))))
 
 (defn ^{Test {:groups ["proxy"

--- a/src/rhsm/gui/tests/proxy_tests.clj
+++ b/src/rhsm/gui/tests/proxy_tests.clj
@@ -228,7 +228,8 @@
       (tasks/verify-conf-proxies hostname port "" ""))
     (let [thrown-error (try+ (register)
                              (catch Object e (:type e)))]
-      (verify (= thrown-error :network-error)))
+      (verify (= thrown-error :network-error))
+      (verify (bool (tasks/ui guiexist :error-dialog))))
     (finally
      (if (bool (tasks/ui guiexist :register-dialog))
        (tasks/ui click :register-close))

--- a/src/rhsm/gui/tests/proxy_tests.clj
+++ b/src/rhsm/gui/tests/proxy_tests.clj
@@ -209,7 +209,10 @@
   (try+
    (tasks/enableproxy "doesnotexist.redhat.com")
    (test_proxy "Proxy connection failed")
-   (finally (tasks/disableproxy))))
+   (finally
+     (if (bool (tasks/ui guiexist :error-dialog))
+       (tasks/ui click :ok-error))
+     (tasks/disableproxy))))
 
 (defn ^{Test {:groups ["proxy"
                        "tier1"]}}

--- a/src/rhsm/gui/tests/proxy_tests.clj
+++ b/src/rhsm/gui/tests/proxy_tests.clj
@@ -27,8 +27,7 @@
 
 (defn ^{BeforeClass {:groups ["setup"]}}
   setup [_]
-  (try+ (if (= "RHEL7" (get-release)) (base/startup nil))
-        (skip-if-bz-open "1142918")
+  (try+ (skip-if-bz-open "1142918")
         (if (not (bool (tasks/ui guiexist :main-window)))
           (tasks/start-app))
         (tasks/unregister)
@@ -230,6 +229,8 @@
     (finally
      (if (bool (tasks/ui guiexist :register-dialog))
        (tasks/ui click :register-close))
+     (if (bool (tasks/ui guiexist :error-dialog))
+       (tasks/ui click :ok-error))
      (disable_proxy nil))))
 
 (defn ^{Test {:groups ["proxy"
@@ -255,6 +256,7 @@
     (finally
      (if (bool (tasks/ui guiexist :facts-dialog))
        (tasks/ui click :close-facts))
+
      (disable_proxy nil))))
 
 (defn ^{Test {:groups ["proxy"

--- a/src/rhsm/gui/tests/proxy_tests.clj
+++ b/src/rhsm/gui/tests/proxy_tests.clj
@@ -210,8 +210,7 @@
    (tasks/enableproxy "doesnotexist.redhat.com")
    (test_proxy "Proxy connection failed")
    (finally
-     (if (bool (tasks/ui guiexist :error-dialog))
-       (tasks/ui click :ok-error))
+     (tasks/close-error-dialog)
      (tasks/disableproxy))))
 
 (defn ^{Test {:groups ["proxy"
@@ -228,14 +227,12 @@
       (tasks/verify-conf-proxies hostname port "" ""))
     (let [thrown-error (try+ (register)
                              (catch Object e (:type e)))]
-      (verify (= thrown-error :network-error))
-      (verify (bool (tasks/ui guiexist :error-dialog))))
+      (verify (= thrown-error :network-error)))
     (finally
-     (if (bool (tasks/ui guiexist :register-dialog))
-       (tasks/ui click :register-close))
-     (if (bool (tasks/ui guiexist :error-dialog))
-       (tasks/ui click :ok-error))
-     (disable_proxy nil))))
+      (if (bool (tasks/ui guiexist :register-dialog))
+        (tasks/ui click :register-close))
+      (tasks/close-error-dialog)
+      (disable_proxy nil))))
 
 (defn ^{Test {:groups ["proxy"
                        "tier2"
@@ -260,8 +257,7 @@
     (finally
      (if (bool (tasks/ui guiexist :facts-dialog))
        (tasks/ui click :close-facts))
-     (if (bool (tasks/ui guiexist :error-dialog))
-       (tasks/ui click :ok-error))
+     (tasks/close-error-dialog)
      (disable_proxy nil))))
 
 (defn ^{Test {:groups ["proxy"


### PR DESCRIPTION
Main point of that PR is that error-dialog appears after bad_proxy test is run.
Cleaning method is sensitive for appearance of any error-dialog.

So I have a added closing of an error-dialog after bad_proxy is finished. 