### PR TITLE
fixed close-error-dialog method

### DIFF
--- a/src/rhsm/gui/tasks/tasks.clj
+++ b/src/rhsm/gui/tasks/tasks.clj
@@ -60,7 +60,7 @@
 
 (defn close-error-dialog
   []
-  (if (ui guiexist :error-dialog)
+  (if (bool (ui guiexist :error-dialog))
     (ui click :ok-error)))
 
 (defn checkforerror


### PR DESCRIPTION
Just one line. Missing type conversion to bool in a test.
I have tested a few tests that use method close-error-dialog.
