### PR TITLE
test enable_repo_remove_all_overrides is skipped for RHEL7.3

### DIFF
--- a/src/rhsm/gui/tests/repo_tests.clj
+++ b/src/rhsm/gui/tests/repo_tests.clj
@@ -295,6 +295,9 @@
   enable_repo_remove_all_overrides
   "Enable all repos and click remove all override and check state"
   [_ repo]
+  (when (-> (get-release :true) :version (= "7.3"))
+    (throw (SkipException.
+            (str "Skip due to a problem with toggle checkbox in RHEL7.3"))))
   (assert-and-open-repo-dialog)
   (tasks/ui selectrow :repo-table repo)
   (sleep 3000)


### PR DESCRIPTION
Added SkipException in the test for RHEL7.3. There is a problem with GTK3 event to toggle checkbox. This checkbox is important for this test.