### PR TITLE
usage of (data-driven was replaced by TestNG dataProvider for tests register_bad_credentials

### DIFF
--- a/src/rhsm/gui/tests/register_tests.clj
+++ b/src/rhsm/gui/tests/register_tests.clj
@@ -81,12 +81,13 @@
                        "blockedByBug-1283749"
                        "blockedByBug-718045"
                        "blockedByBug-1194365"
-                       "blockedByBug-1249723"]
+                       "blockedByBug-1249723"
+                       "blockedByBug-1194365"]
               :dataProvider "bad-credentials and corresponding errors"}}
   register_bad_credentials
   "Checks error messages upon registering with bad credentials."
   [_ register-args expected-error]
-  (skip-if-bz-open "1194365")
+  ;(skip-if-bz-open "1194365")
   (try+ (tasks/unregister) (catch [:type :not-registered] _))
   (when (or (bool (tasks/ui guiexist :register-dialog))
             (bool (tasks/ui guiexist :error-dialog)))

--- a/src/rhsm/gui/tests/register_tests.clj
+++ b/src/rhsm/gui/tests/register_tests.clj
@@ -75,9 +75,17 @@
       (finally (if (bool (tasks/ui guiexist :facts-dialog))
                  (tasks/ui click :close-facts))))))
 
-(defn register_bad_credentials
+(defn ^{Test {:groups ["registration"
+                       "tier1"
+                       "blockedByBug-1255805"
+                       "blockedByBug-1283749"
+                       "blockedByBug-718045"
+                       "blockedByBug-1194365"
+                       "blockedByBug-1249723"]
+              :dataProvider "bad-credentials and corresponding errors"}}
+  register_bad_credentials
   "Checks error messages upon registering with bad credentials."
-  [register-args expected-error]
+  [_ register-args expected-error]
   (skip-if-bz-open "1194365")
   (try+ (tasks/unregister) (catch [:type :not-registered] _))
   (when (or (bool (tasks/ui guiexist :register-dialog))
@@ -94,23 +102,6 @@
       (verify (bool (tasks/ui guiexist :register-dialog)))
       (tasks/ui click :register-close)
       (tasks/close-error-dialog))))
-
-(data-driven register_bad_credentials {Test {:groups ["registration"
-                                                      "tier1"
-                                                      "blockedByBug-1255805"
-                                                      "blockedByBug-1283749"]}}
-   [^{Test {:groups ["blockedByBug-718045"
-                     "blockedByBug-1194365"
-                     "blockedByBug-1249723"]}}
-    [["sdf" "sdf"] :invalid-credentials]
-    ;^{Test {:groups ["blockedByBug-719378"]}}
-    [["test user" "password"] :invalid-credentials]
-    [["test user" ""] :no-password]
-    [["  " "  "] :no-username]
-    [["" ""] :no-username]
-    [["" "password"] :no-username]
-    [["sdf" ""] :no-password]
-    [[(@config :username) (@config :password) :system-name-input ""] :no-system-name]])
 
 (defn ^{Test {:groups ["registration"
                        "tier1"
@@ -338,6 +329,19 @@
         (if-not debug
           (to-array-2d data)
           data)))
+    (to-array-2d [])))
+
+(defn ^{DataProvider {:name "bad-credentials and corresponding errors"}}
+  get_bad_credentials_and_corresponding_errors [ _ ]
+  (if-not (assert-skip :register)
+    (to-array-2d [[["sdf" "sdf"] :invalid-credentials]
+                  [["test user" "password"] :invalid-credentials]
+                  [["test user" ""] :no-password]
+                  [["  " "  "] :no-username]
+                  [["" ""] :no-username]
+                  [["" "password"] :no-username]
+                  [["sdf" ""] :no-password]
+                  [[(@config :username) (@config :password) :system-name-input ""] :no-system-name]])
     (to-array-2d [])))
 
 (gen-class-testng)

--- a/test/rhsm/gui/tasks/tools_test.clj
+++ b/test/rhsm/gui/tasks/tools_test.clj
@@ -7,13 +7,20 @@
              [rhsm.runtestng]
              [slingshot.slingshot :as sl]
              [clojure.string :as s]
-             [mount.core :as mount]))
+))
 
 
-(use-fixtures :once (fn [f] (base/startup nil)(f)))
+(use-fixtures :once (fn [f]
+                      (base/startup nil)
+                      (f)))
 
 (deftest rhel-version-test
   (let [{:keys [family variant version]} (tt/get-release :true)]
     (is (re-find #"^RHEL[0-9]$" family))
     (is (re-find #"^Server|Client$" variant))
     (is (re-find #"^[0-9]\.[0-9]$" version))))
+
+(deftest get-locale-regex-test
+  (testing "This test validates that get-locale-regex provides the right regex"
+    (let [ datex (tt/get-locale-regex)]
+      (is (not (nil? (re-matches datex "07/07/2016")))))))

--- a/test/rhsm/gui/tests/repo_test.clj
+++ b/test/rhsm/gui/tests/repo_test.clj
@@ -1,0 +1,32 @@
+(ns rhsm.gui.tests.repo-test
+  (:use gnome.ldtp)
+  (:require  [clojure.test :refer :all]
+             [rhsm.gui.tests.repo_tests :as tests]
+             [rhsm.gui.tasks.tasks :as tasks]
+             [rhsm.gui.tasks.tools :as tools]
+             [rhsm.gui.tasks.test-config :as c]
+             [rhsm.gui.tests.base :as base]
+             [rhsm.gui.tests.testbase :as testbase])
+  (:import org.testng.SkipException))
+
+;; initialization of our testware
+(use-fixtures :once (fn [f]
+                      (println "------ base/startup ------")
+                      (base/startup nil)
+                      (println "------ tests/setup ------")
+                      (tests/setup nil)
+                      (println "------ test ------")
+                      (f)))
+
+
+(deftest check_repo_name_url-test
+  (let [repos  (tests/subscribed_repos nil)]
+    (tests/check_repo_name_url nil (-> repos first first))))
+
+(deftest enable_repo_remove_all_overrides-test
+  (let [repos (tests/subscribed_repos nil)]
+    (if (-> (tools/get-release :true) :version (= "7.3"))
+      (is (thrown? SkipException
+                   (tests/enable_repo_remove_all_overrides nil (-> repos first first))))
+      (tests/enable_repo_remove_all_overrides nil (-> repos first first))))
+  (tests/after_enable_repo_remove_all_overrides nil))

--- a/test/rhsm/gui/tests/subscribe_test.clj
+++ b/test/rhsm/gui/tests/subscribe_test.clj
@@ -1,0 +1,26 @@
+(ns rhsm.gui.tests.subscribe-test
+  (:use [slingshot.slingshot :only (try+
+                                    throw+)]
+        [com.redhat.qe.verify :only (verify)]
+        gnome.ldtp
+        rhsm.gui.tasks.tools)
+  (:require  [clojure.test :refer :all]
+             [rhsm.gui.tests.subscribe_tests :as tests]
+             [rhsm.gui.tasks.tasks :as tasks]
+
+             [rhsm.gui.tasks.ui :as ui]
+             [rhsm.gui.tasks.test-config :as c]
+             [rhsm.gui.tests.base :as base]))
+
+;; ;; initialization of our testware
+(use-fixtures :once (fn [f]
+                      (base/startup nil)
+                      (tests/register nil)
+                      (f)))
+
+(deftest multi-contract-test
+  (tests/get_multi_contract_subscriptions nil :debug true))
+
+(deftest check_contract_selection_dates-test
+  (let [subscriptions (tests/get_multi_contract_subscriptions nil :debug true)]
+    (tests/check_contract_selection_dates nil #spy/d (-> subscriptions first first))))


### PR DESCRIPTION
It is so because data are prepared in compile time. That is why the last data pair is empty since it is created from @config variable.