### PR TITLE
remembered original value of productCertDir and added product-default path

### DIFF
--- a/src/rhsm/gui/tests/autosubscribe_tests.clj
+++ b/src/rhsm/gui/tests/autosubscribe_tests.clj
@@ -43,6 +43,8 @@
 (def sla-list (atom nil))
 (def entitlement-map (atom nil))
 
+(def product-cert-dir (atom nil))
+
 (defn- dirsetup? [dir]
   (and
    (= "exists" (trim
@@ -64,6 +66,7 @@
     (verify (not (.isBugOpen (BzChecker/getInstance) "1040119")))
     (if (= "RHEL7" (get-release)) (base/startup nil))
     (tasks/kill-app)
+    (reset! product-cert-dir (tasks/conf-file-value "productCertDir"))
     (reset! complytests (ComplianceTests. ))
     (.setupProductCertDirsBeforeClass @complytests)
     (let [safe-upper (fn [s] (if s (.toUpperCase s) nil))]
@@ -85,7 +88,7 @@
   (assert-valid-testing-arch)
   (run-command "subscription-manager unregister")
   (.configureProductCertDirAfterClass @complytests)
-  (tasks/set-conf-file-value "productCertDir" (@config :sm-rhsm-product-cert-dir))
+  (tasks/set-conf-file-value "productCertDir" @product-cert-dir)
   (tasks/restart-app))
 
 (defn ^{Test {:groups ["autosubscribe"

--- a/src/rhsm/gui/tests/facts_tests.clj
+++ b/src/rhsm/gui/tests/facts_tests.clj
@@ -210,7 +210,8 @@
   [_]
   (let [certdir (tasks/conf-file-value "productCertDir")
         rhelcerts ["68" "69" "71" "72" "74" "76"]
-        certlist (map #(str certdir "/" % ".pem") rhelcerts)
+        certlist (into (map #(str certdir "/" % ".pem") rhelcerts)
+                       (map #(str certdir "-default/" % ".pem") rhelcerts))
         certexist? (map #(= 0 (:exitcode
                                (run-command (str "test -f " %))))
                         certlist)]


### PR DESCRIPTION
autosubscribe_tests suite remembers original value of "productCertDir" now.
It is used to clean up the suite.

product-default is used to find cert files in facts_tests above that "product" dir.