### PR TITLE
fixed check_repo_visible

### DIFF
--- a/src/rhsm/gui/tests/repo_tests.clj
+++ b/src/rhsm/gui/tests/repo_tests.clj
@@ -150,7 +150,7 @@
   [_]
   (tasks/restart-app :unregister? true)
   (tasks/ui click :main-window "System")
-  (verify (not (tasks/visible? :repositories))))
+  (verify (not (tasks/has-state? :repositories "enabled"))))
 
 (defn ^{Test {:groups ["repo"
                        "tier1"


### PR DESCRIPTION
repositories is disabled when system is unregistered. It is OK.
I have changed visible? to has-state :repositories "enabled".
