### PR TITLE
fixed check_message_after_attaching.

### DIFF
--- a/src/rhsm/gui/tests/subscription_status_tests.clj
+++ b/src/rhsm/gui/tests/subscription_status_tests.clj
@@ -95,27 +95,25 @@
   "Asserts that status message displayed in main-window is right after attaching subscriptions"
   [_]
   (try
-    (let [subscribed-products (atom (int 0))
-          after-subscribe (atom (int 0))]
-      (tasks/search :match-installed? true)
-      (log/info "'Overall status' at the beginning of this test: " (tasks/ui gettextvalue :overall-status))
-      (log/info "Num of subscriptions that can be attached: " (tasks/ui getrowcount :all-subscriptions-view))
-      ;; (dotimes [n (min 3 (Integer. (tasks/ui getrowcount :all-subscriptions-view)))] ;; max 3 times repeat that
-      (loop [n 3
-             num-of-subscriptions (Integer. (tasks/ui getrowcount :all-subscriptions-view))]
-        (when (> (min n num-of-subscriptions) 0)
-          (tasks/subscribe (tasks/ui getcellvalue :all-subscriptions-view
-                                     (rand-int (tasks/ui getrowcount :all-subscriptions-view)) 0))
-          (when (bool (tasks/ui guiexist :all-subscriptions-view))
-            (recur (dec n) (Integer. (tasks/ui getrowcount :all-subscriptions-view))))))
-
-      (log/info "'Overall status' at the end of this test: " (tasks/ui gettextvalue :overall-status))
-      (reset! subscribed-products (count (filter #(= "Subscribed" %)
-                                                 (tasks/get-table-elements :installed-view 2))))
-      (reset! after-subscribe (if-let [num (re-find #"^\d+" (tasks/ui gettextvalue :overall-status))]
-                                (Integer. num)
-                                0))
-      (verify (= @after-subscribe (- @status-before-subscribe @subscribed-products))))))
+    (tasks/search :match-installed? true)
+    (log/info "'Overall status' at the beginning of this test: " (tasks/ui gettextvalue :overall-status))
+    (log/info "Num of subscriptions that can be attached: " (tasks/ui getrowcount :all-subscriptions-view))
+    ;; (dotimes [n (min 3 (Integer. (tasks/ui getrowcount :all-subscriptions-view)))] ;; max 3 times repeat that
+    (loop [n 3
+           num-of-subscriptions (Integer. (tasks/ui getrowcount :all-subscriptions-view))]
+      (when (> (min n num-of-subscriptions) 0)
+        (tasks/subscribe (tasks/ui getcellvalue :all-subscriptions-view
+                                   (rand-int num-of-subscriptions) 0))
+        (when (bool (tasks/ui guiexist :all-subscriptions-view))
+          (recur (dec n) (Integer. (tasks/ui getrowcount :all-subscriptions-view))))))
+    (log/info "'Overall status' at the end of this test: " (tasks/ui gettextvalue :overall-status))
+    (let [subscribed-products (count (filter #(= "Subscribed" %)
+                                             (tasks/get-table-elements :installed-view 2)))
+          after-subscribe (if-let [num (re-find #"^\d+" (tasks/ui gettextvalue :overall-status))]
+                            (Integer. num)
+                            0)
+          before-subscribe @status-before-subscribe]
+      (verify (= after-subscribe (- before-subscribe subscribed-products))))))
 
 (defn ^{Test {:groups ["subscription_status"
                        "tier1"

--- a/src/rhsm/gui/tests/subscription_status_tests.clj
+++ b/src/rhsm/gui/tests/subscription_status_tests.clj
@@ -95,17 +95,26 @@
   "Asserts that status message displayed in main-window is right after attaching subscriptions"
   [_]
   (try
-    (let
-  	[subscribed-products (atom (int 0))
-         after-subscribe (atom (int 0))]
+    (let [subscribed-products (atom (int 0))
+          after-subscribe (atom (int 0))]
       (tasks/search :match-installed? true)
-      (dotimes [n 3]
-        (tasks/subscribe (tasks/ui getcellvalue :all-subscriptions-view
-                                   (rand-int (tasks/ui getrowcount :all-subscriptions-view)) 0)))
+      (log/info "'Overall status' at the beginning of this test: " (tasks/ui gettextvalue :overall-status))
+      (log/info "Num of subscriptions that can be attached: " (tasks/ui getrowcount :all-subscriptions-view))
+      ;; (dotimes [n (min 3 (Integer. (tasks/ui getrowcount :all-subscriptions-view)))] ;; max 3 times repeat that
+      (loop [n 3
+             num-of-subscriptions (Integer. (tasks/ui getrowcount :all-subscriptions-view))]
+        (when (> (min n num-of-subscriptions) 0)
+          (tasks/subscribe (tasks/ui getcellvalue :all-subscriptions-view
+                                     (rand-int (tasks/ui getrowcount :all-subscriptions-view)) 0))
+          (when (bool (tasks/ui guiexist :all-subscriptions-view))
+            (recur (dec n) (Integer. (tasks/ui getrowcount :all-subscriptions-view))))))
+
+      (log/info "'Overall status' at the end of this test: " (tasks/ui gettextvalue :overall-status))
       (reset! subscribed-products (count (filter #(= "Subscribed" %)
                                                  (tasks/get-table-elements :installed-view 2))))
-      (reset! after-subscribe (Integer. (re-find #"\d*"
-                                                 (tasks/ui gettextvalue :overall-status))))
+      (reset! after-subscribe (if-let [num (re-find #"^\d+" (tasks/ui gettextvalue :overall-status))]
+                                (Integer. num)
+                                0))
       (verify (= @after-subscribe (- @status-before-subscribe @subscribed-products))))))
 
 (defn ^{Test {:groups ["subscription_status"

--- a/test/rhsm/gui/tests/autosubscribe_test.clj
+++ b/test/rhsm/gui/tests/autosubscribe_test.clj
@@ -1,20 +1,36 @@
 (ns rhsm.gui.tests.autosubscribe-test
-  (:use gnome.ldtp
-        rhsm.gui.tasks.tools
-        [rhsm.gui.tasks.test-config :only (config clientcmd)])
   (:require  [clojure.test :refer :all]
-             [rhsm.gui.tests.autosubscribe_tests :as atests]
+             [rhsm.gui.tests.autosubscribe_tests :as tests]
              [rhsm.gui.tasks.tasks :as tasks]
-             [rhsm.gui.tasks.tools :as tt]
+             [rhsm.gui.tasks.tools :as tools]
              [rhsm.gui.tasks.ui :as ui]
              [rhsm.gui.tasks.test-config :as c]
-             [rhsm.gui.tests.base :as base]))
+             [rhsm.gui.tests.base :as base]
+             ;[rhsm.gui.tests.testbase :as testbase]
+             ))
 
 ;; ;; initialization of our testware
 (use-fixtures :once (fn [f]
                       (base/startup nil)
-                      (atests/setup nil) (f)))
+                      (tests/setup nil)
+                      (f)
+                      (tests/cleanup nil)))
 
 (deftest simple_autosubscribe-test
   (testing "run of one test for autosubscribe"
-    (atests/simple_autosubscribe nil)))
+    ;; (println "----> product cert dir: " (tasks/conf-file-value "productCertDir"))
+    ;; (println "----> num of certs:" (-> "ls -1 /tmp/sm-allProductsSubscribableByOneCommonServiceLevel | wc -l" tools/run-command :stdout clojure.string/trim))
+    ;; (println "----------- moveOriginalProductCertDefaultDirFilesBeforeClass ----------------")
+    (.moveOriginalProductCertDefaultDirFilesBeforeClass @tests/complytests)
+    ;; (println "----> product cert dir: " (tasks/conf-file-value "productCertDir"))
+    ;; (println "----> num of certs:" (-> "ls -1 /tmp/sm-allProductsSubscribableByOneCommonServiceLevel | wc -l" tools/run-command :stdout clojure.string/trim))
+    ;; (println "----------- setupProductCertDirsBeforeClass ----------------")
+    (.setupProductCertDirsBeforeClass @tests/complytests)
+    ;; (println "----> product cert dir: " (tasks/conf-file-value "productCertDir"))
+    ;; (println "----> num of certs:" (-> "ls -1 /tmp/sm-allProductsSubscribableByOneCommonServiceLevel | wc -l" tools/run-command :stdout clojure.string/trim))
+    ;; (println "----------- configureProductCertDirForAllProductsSubscribableByOneCommonServiceLevel ----------------")
+    (.configureProductCertDirForAllProductsSubscribableByOneCommonServiceLevel @tests/complytests)
+    ;; (println "----> product cert dir: " (tasks/conf-file-value "productCertDir"))
+    ;; (println "----> num of certs:" (-> "ls -1 /tmp/sm-allProductsSubscribableByOneCommonServiceLevel | wc -l" tools/run-command :stdout clojure.string/trim))
+    ;; (println "----------- simple_autosubscribe ----------------")
+    (tests/simple_autosubscribe nil)))


### PR DESCRIPTION
There were more than one use cases that this PR solves:
- there are less than 3 subscriptions in a system
- "All Subscriptions table" disappears after attaching one subscription even two subscriptions was available