### PR TITLE
proxy auth tests has had old path for a file tinyproxy.log

### DIFF
--- a/src/rhsm/gui/tasks/test_config.clj
+++ b/src/rhsm/gui/tasks/test_config.clj
@@ -46,7 +46,7 @@
                          :noauth-proxy-port "sm.noauthproxy.port"
                          :noauth-proxy-log (DefaultMapKey.
                                              "sm.noauthproxy.log"
-                                             "/var/log/tinyproxy.log")
+                                             "/var/log/tinyproxy/tinyproxy.log")
 
                          ;binary paths
                          :binary-path (DefaultMapKey.

--- a/src/rhsm/gui/tests/proxy_tests.clj
+++ b/src/rhsm/gui/tests/proxy_tests.clj
@@ -19,8 +19,6 @@
             BeforeGroups
             AfterGroups]))
 
-(def auth-log "/var/log/squid/access.log")
-(def noauth-log "/var/log/tinyproxy.log")
 (def rhsm-log "/var/log/rhsm/rhsm.log")
 (def ldtpd-log "/var/log/ldtpd/ldtpd.log")
 (def proxy-success "Proxy connection succeeded")
@@ -86,7 +84,7 @@
   [_]
   (enable_proxy_auth nil)
   (let [logoutput (get-logging @auth-proxyrunner
-                               auth-log
+                               (@config :basicauth-proxy-log)
                                "proxy-auth-connect"
                                nil
                                (register))]
@@ -100,7 +98,7 @@
   [_]
   (enable_proxy_noauth nil)
   (let [logoutput (get-logging @noauth-proxyrunner
-                               noauth-log
+                               (@config :noauth-proxy-log)
                                "proxy-noauth-connect"
                                nil
                                (register))]
@@ -115,13 +113,13 @@
   (disable_proxy nil)
   ;; note: if this takes forever, blank out the proxy log file.
   (let [logoutput (get-logging @auth-proxyrunner
-                               auth-log
+                               (@config :basicauth-proxy-log)
                                "disabled-auth-connect"
                                nil
                                (register))]
     (verify (clojure.string/blank? logoutput)))
   (let [logoutput (get-logging @noauth-proxyrunner
-                               noauth-log
+                               (@config :noauth-proxy-log)
                                "disabled-noauth-connect"
                                nil
                                (register))]

--- a/test/rhsm/gui/tests/proxy_test.clj
+++ b/test/rhsm/gui/tests/proxy_test.clj
@@ -1,0 +1,28 @@
+(ns rhsm.gui.tests.proxy-test
+  (:require  [clojure.test :refer :all]
+             [rhsm.gui.tests.proxy_tests :as tests]
+             [rhsm.gui.tasks.tasks :as tasks]
+             [rhsm.gui.tasks.tools :as tools]
+             [rhsm.gui.tasks.ui :as ui]
+             [rhsm.gui.tests.base :as base]
+             [rhsm.gui.tasks.test-config :as c]
+             [rhsm.gui.tests.testbase :as testbase]))
+
+;; ;; initialization of our testware
+(use-fixtures :once (fn [f]
+                      (base/startup nil)
+                      (tests/setup nil)
+                      (f)
+                      (tests/cleanup nil)))
+
+;; (deftest bad_proxy-test
+;;   (tests/test_bad_proxy nil))
+
+;; (deftest proxy_test-test
+;;   (tests/bad_proxy nil))
+
+(deftest test_proxy_with_blank_credentials-test
+  (tests/test_proxy_with_blank_credentials nil))
+
+;; (deftest proxy_noauth_connect-test
+;;   (tests/proxy_noauth_connect nil))


### PR DESCRIPTION
I have updated test-config and proxy tests that use this path.