### PR TITLE
added blockedByBug for test_proxy_with_blank_location

### DIFF
--- a/src/rhsm/gui/tests/proxy_tests.clj
+++ b/src/rhsm/gui/tests/proxy_tests.clj
@@ -175,7 +175,8 @@
 
 (defn ^{Test {:groups ["proxy"
                        "tier1"
-                       "blockedByBug-927340"]
+                       "blockedByBug-927340"
+                       "blockedByBug-1371632"]
               :dependsOnMethods ["disable_proxy"]}}
   test_proxy_with_blank_proxy
   "Test whether 'Test Connection' returns appropriate message when 'Location Proxy' is empty"


### PR DESCRIPTION
This test is blocked by the same bugzilla bugs as a test "check_proxy_blank_credentials".