### PR TITLE
Test for <ctrl-c> pressed in a terminal with 'subscription-manager-gui' running

### DIFF
--- a/src/rhsm/gui/tests/system_tests.clj
+++ b/src/rhsm/gui/tests/system_tests.clj
@@ -101,7 +101,7 @@
               :description "Given 'subscription-manager-gui' is not running
   and I have launched 'gnome-terminal'
 When I launch 'subscription-manager-gui' in the terminal
-  and I wait a little
+  and I wait 5 seconds
   and I press <Ctrl-C> in the terminal
 Then I should not see any 'Traceback' written in the terminal
   and I should not see 'subscription-manager-gui' running."}}
@@ -115,7 +115,7 @@ Then I should not see any 'Traceback' written in the terminal
                            last) ]
     (tasks/ui grabfocus terminal-name "uknTerminal")
     (tasks/ui generatekeyevent "subscription-manager-gui<enter>")
-    (tasks/ui waittillwindowexist :main-window 10)
+    (tasks/ui waittillwindowexist :main-window 5)
     (tasks/ui grabfocus terminal-name "uknTerminal")
     (tasks/ui generatekeyevent "<ctrl>c")
     (try
@@ -129,7 +129,7 @@ Then I should not see any 'Traceback' written in the terminal
                                       (Thread/sleep 100)
                                       (if (and (< number-of-iteration 5)
                                                (not traceback-appeared?))
-                                        (recur (get-text-from-terminal) (+ 1 number-of-iteration))
+                                        (recur (get-text-from-terminal) (inc number-of-iteration))
                                         traceback-appeared?))))]
         (verify (not traceback-appeared?))
         (verify (not (-> (tasks/ui guiexist :main-window) bool))))

--- a/src/rhsm/gui/tests/system_tests.clj
+++ b/src/rhsm/gui/tests/system_tests.clj
@@ -96,6 +96,48 @@
   (tasks/kill-app))
 
 (defn ^{Test {:groups ["system"
+                       "tier2"
+                       "blockedByBug-1330515"]
+              :description "Given 'subscription-manager-gui' is not running
+  and I have launched 'gnome-terminal'
+When I launch 'subscription-manager-gui' in the terminal
+  and I wait a little
+  and I press <Ctrl-C> in the terminal
+Then I should not see any 'Traceback' written in the terminal
+  and I should not see 'subscription-manager-gui' running."}}
+  no_traceback_on_console_after_ctrl_c_pressed
+  [_]
+  (when (-> (tasks/ui guiexist :main-window) bool)
+    (tasks/kill-app))
+  (tasks/ui launchapp "gnome-terminal")
+  (let [terminal-name (->> (tasks/ui getwindowlist)
+                           (filter (fn [item] (.contains item "frmTerminal")))
+                           last) ]
+    (tasks/ui grabfocus terminal-name "uknTerminal")
+    (tasks/ui generatekeyevent "subscription-manager-gui<enter>")
+    (tasks/ui waittillwindowexist :main-window 10)
+    (tasks/ui grabfocus terminal-name "uknTerminal")
+    (tasks/ui generatekeyevent "<ctrl>c")
+    (try
+      (let [traceback-appeared? (letfn [(get-text-from-terminal []
+                                          (-> (tasks/ui gettextvalue terminal-name "uknTerminal")
+                                              clojure.string/trim))]
+                                  (loop [text (get-text-from-terminal)
+                                         number-of-iteration 1]
+                                    (let [traceback-appeared?
+                                          (.contains text "Traceback (most recent call last):")]
+                                      (Thread/sleep 100)
+                                      (if (and (< number-of-iteration 5)
+                                               (not traceback-appeared?))
+                                        (recur (get-text-from-terminal) (+ 1 number-of-iteration))
+                                        traceback-appeared?))))]
+        (verify (not traceback-appeared?))
+        (verify (not (bool (tasks/ui guiexist :main-window)))))
+      (finally
+        (tasks/kill-app)
+        (tasks/ui click terminal-name "mnuCloseAllTerminals")))))
+
+(defn ^{Test {:groups ["system"
                        "tier1"
                        "blockedByBug-706384"]}}
   run_second_instance

--- a/src/rhsm/gui/tests/system_tests.clj
+++ b/src/rhsm/gui/tests/system_tests.clj
@@ -132,7 +132,7 @@ Then I should not see any 'Traceback' written in the terminal
                                         (recur (get-text-from-terminal) (+ 1 number-of-iteration))
                                         traceback-appeared?))))]
         (verify (not traceback-appeared?))
-        (verify (not (bool (tasks/ui guiexist :main-window)))))
+        (verify (not (-> (tasks/ui guiexist :main-window) bool))))
       (finally
         (tasks/kill-app)
         (tasks/ui click terminal-name "mnuCloseAllTerminals")))))

--- a/test/rhsm/gui/tests/system_test.clj
+++ b/test/rhsm/gui/tests/system_test.clj
@@ -1,0 +1,23 @@
+(ns rhsm.gui.tests.system-test
+  (:use gnome.ldtp
+        rhsm.gui.tasks.tools)
+  (:import org.testng.SkipException)
+  (:require  [clojure.test :refer :all]
+             [rhsm.gui.tests.system_tests :as tests]
+             [rhsm.gui.tasks.tools :as tools]
+             [rhsm.gui.tasks.tasks :as tasks]
+             [clojure.core.match :refer [match]]
+             [rhsm.gui.tests.base :as base]))
+
+(use-fixtures :once (fn [f]
+                      (base/startup nil)
+                      (f)))
+
+(deftest no_traceback_on_console_after_ctrl_c_pressed-test
+  (let [{:keys [major minor patch]} (tools/subman-version)]
+    (if (or (and (= (Integer. major) 1) (= (Integer. minor) 17) (>= (Integer. patch) 15))
+            (and (= (Integer. major) 1) (> (Integer. minor) 17))
+            (> (Integer. major) 1))
+      (tests/no_traceback_on_console_after_ctrl_c_pressed nil)
+      (is (thrown? java.lang.AssertionError
+                   (tests/no_traceback_on_console_after_ctrl_c_pressed nil))))))


### PR DESCRIPTION
I have added a test for 'subscription-manager-gui'.
It verifies that no traceback appears in "gnome-terminal" after I pressed <ctrl-c>.
The application is started in the terminal.