### PR TITLE
Fix for enable repo remove all overrides

### DIFF
--- a/src/rhsm/gui/tasks/tasks.clj
+++ b/src/rhsm/gui/tasks/tasks.clj
@@ -1098,3 +1098,11 @@ The function uses an utility 'import' from package 'imagemagick'"
                        (format "%s-screenshot-%s@%s.png" jenkins-run-id name suffix))]
       (run-command (format "DISPLAY=:2 import -window root %s" image-name))
       image-name)))
+
+
+(defmacro verify-or-take-screenshot
+  [expr]
+  `(try+ (verify ~expr)
+         (catch Object e#
+           (take-screenshot "not-verified")
+           (throw+))))

--- a/src/rhsm/gui/tasks/tasks.clj
+++ b/src/rhsm/gui/tasks/tasks.clj
@@ -1081,3 +1081,20 @@ Column index starts from 0"
                                          get-sorting))]
       ;; If I click twice I should see two different sort orders in the same column
       (= (set [:desc-sorting :asc-sorting]) (set [sorting-after-click-01 sorting-after-click-02])))))
+
+(defn take-screenshot
+  [name]
+  "The function saves screenshot of a desktop root.
+It appends timestamp at the end of a name.
+If the function finds 'BUILD_TAG' it uses it as prefix for image name.
+
+'BUILD_TAG' is set by Jenkins and depends on an actual build.
+
+The function uses an utility 'import' from package 'imagemagick'"
+  (let [suffix (-> (java.time.Instant/now) (.toString))
+        jenkins-run-id (System/getenv "BUILD_TAG")]
+    (let [image-name (if (clojure.string/blank? jenkins-run-id)
+                       (format "screenshot-%s@%s.png" name suffix)
+                       (format "%s-screenshot-%s@%s.png" jenkins-run-id name suffix))]
+      (run-command (format "DISPLAY=:2 import -window root %s" image-name))
+      image-name)))

--- a/src/rhsm/gui/tasks/tasks.clj
+++ b/src/rhsm/gui/tasks/tasks.clj
@@ -1096,7 +1096,7 @@ The function uses an utility 'import' from package 'imagemagick'"
     (let [image-name (if (clojure.string/blank? jenkins-run-id)
                        (format "screenshot-%s@%s.png" name suffix)
                        (format "%s-screenshot-%s@%s.png" jenkins-run-id name suffix))]
-      (run-command (format "DISPLAY=:2 import -window root %s" image-name))
+      (run-command (format "DISPLAY=:2 import -window root '%s'" image-name))
       image-name)))
 
 (defmacro verify-or-take-screenshot

--- a/src/rhsm/gui/tasks/tasks.clj
+++ b/src/rhsm/gui/tasks/tasks.clj
@@ -1107,8 +1107,8 @@ The function uses an utility 'import' from package 'imagemagick'"
            (throw+))))
 
 (defmacro screenshot-on-exception
-  [body]
+  [& body]
   `(try+ ~@body
          (catch Object e#
-           (take-screenshot "screenshot-on-exception")
+           (take-screenshot "on-exception")
            (throw+))))

--- a/src/rhsm/gui/tasks/tasks.clj
+++ b/src/rhsm/gui/tasks/tasks.clj
@@ -1099,10 +1099,16 @@ The function uses an utility 'import' from package 'imagemagick'"
       (run-command (format "DISPLAY=:2 import -window root %s" image-name))
       image-name)))
 
-
 (defmacro verify-or-take-screenshot
   [expr]
   `(try+ (verify ~expr)
          (catch Object e#
            (take-screenshot "not-verified")
+           (throw+))))
+
+(defmacro screenshot-on-exception
+  [body]
+  `(try+ ~@body
+         (catch Object e#
+           (take-screenshot "screenshot-on-exception")
            (throw+))))

--- a/src/rhsm/gui/tests/repo_tests.clj
+++ b/src/rhsm/gui/tests/repo_tests.clj
@@ -343,9 +343,9 @@ Then I see values of repositories ids to be redrawn
   (sleep 3000)
   (let [row-num (tasks/ui gettablerowindex :repo-table repo)]
     (toggle-checkbox-state row-num))
-  (verify (tasks/has-state? :repo-remove-override "enabled"))
+  (tasks/verify-or-take-screenshot (tasks/has-state? :repo-remove-override "enabled"))
   (assert-and-remove-all-override)
-  (verify (not (tasks/has-state? :repo-remove-override "enabled"))))
+  (tasks/verify-or-take-screenshot (not (tasks/has-state? :repo-remove-override "enabled"))))
 
 (defn ^{AfterGroups {:groups ["repo"
                               "tier3"]

--- a/src/rhsm/gui/tests/repo_tests.clj
+++ b/src/rhsm/gui/tests/repo_tests.clj
@@ -338,14 +338,15 @@ Then I see values of repositories ids to be redrawn
   (when (-> (get-release :true) :version (= "7.3"))
     (throw (SkipException.
             (str "Skip due to a problem with toggle checkbox in RHEL7.3"))))
-  (assert-and-open-repo-dialog)
-  (tasks/ui selectrow :repo-table repo)
-  (sleep 3000)
-  (let [row-num (tasks/ui gettablerowindex :repo-table repo)]
-    (toggle-checkbox-state row-num))
-  (tasks/verify-or-take-screenshot (tasks/has-state? :repo-remove-override "enabled"))
-  (assert-and-remove-all-override)
-  (tasks/verify-or-take-screenshot (not (tasks/has-state? :repo-remove-override "enabled"))))
+  (tasks/screenshot-on-exception
+   (assert-and-open-repo-dialog)
+   (tasks/ui selectrow :repo-table repo)
+   (sleep 3000)
+   (let [row-num (tasks/ui gettablerowindex :repo-table repo)]
+     (toggle-checkbox-state row-num))
+   (verify (tasks/has-state? :repo-remove-override "enabled"))
+   (assert-and-remove-all-override)
+   (verify (not (tasks/has-state? :repo-remove-override "enabled")))))
 
 (defn ^{AfterGroups {:groups ["repo"
                               "tier3"]

--- a/test/rhsm/gui/tasks/tasks_test.clj
+++ b/test/rhsm/gui/tasks/tasks_test.clj
@@ -11,8 +11,16 @@
              [mount.core :as mount]))
 
 
-(use-fixtures :once (fn [f] (base/startup nil)(f)))
+(use-fixtures :once (fn [f]
+                      (base/startup nil)
+                      (f)))
 
 (deftest register-with-creds-test
   (t/restart-app)
   (t/register-with-creds))
+
+(deftest take-screenshot-test
+  (t/take-screenshot "test"))
+
+(deftest verify-or-take-screenshot-test
+  (t/verify-or-take-screenshot false))


### PR DESCRIPTION
I have added a function 'take-screenshot'.
I have added macro 'verify-or-take-screenshot'
i have switched 'verify' to 'verify-or-take-screenshot' in one repos test.