### PR TITLE
Fix for check repo message unsubscribed

### DIFF
--- a/src/rhsm/gui/tests/repo_tests.clj
+++ b/src/rhsm/gui/tests/repo_tests.clj
@@ -167,8 +167,8 @@
     (assert-and-open-repo-dialog)
     (verify (bool (tasks/ui guiexist :repositories-dialog)))
     (finally
-      (sleep 2000)
-      (tasks/ui click :close-repo-dialog))))
+      (when (-> (tasks/ui guiexist :repositories-dialog) bool)
+        (tasks/ui click :close-repo-dialog)))))
 
 (defn ^{Test {:groups ["repo"
                        "tier2"
@@ -180,10 +180,11 @@
     (if (tasks/ui showing? :register-system)
       (tasks/register-with-creds))
     (assert-and-open-repo-dialog)
-    (verify (bool (tasks/ui guiexist :repositories-dialog)))
+    (verify (-> (tasks/ui guiexist :repositories-dialog) bool))
     (verify (= no_repos_message (tasks/ui gettextvalue :repo-message)))
     (finally
-      (tasks/ui click :close-repo-dialog))))
+      (when (-> (tasks/ui guiexist :repositories-dialog) bool)
+        (tasks/ui click :close-repo-dialog)))))
 
 (defn ^{Test {:groups ["repo"
                        "tier2"

--- a/src/rhsm/gui/tests/repo_tests.clj
+++ b/src/rhsm/gui/tests/repo_tests.clj
@@ -220,7 +220,8 @@ Then I see values of repositories ids to be redrawn
         ;; I click twice and I get two different sort orders
         (verify (= (set [:desc-sorting :asc-sorting]) (set [sorting-after-click-01 sorting-after-click-02])))))
     (finally
-      (tasks/ui click :close-repo-dialog)
+      (when (-> (tasks/ui guiexist :repositories-dialog) bool)
+        (tasks/ui click :close-repo-dialog))
       (tasks/unsubscribe_all))))
 
 (defn ^{Test {:groups ["repo"
@@ -237,7 +238,8 @@ Then I see values of repositories ids to be redrawn
     (verify (bool (tasks/ui guiexist :repositories-dialog)))
     (verify (< 0 (tasks/ui getrowcount :repo-table)))
     (finally
-      (tasks/ui click :close-repo-dialog)
+      (when (-> (tasks/ui guiexist :repositories-dialog) bool)
+        (tasks/ui click :close-repo-dialog))
       (tasks/unsubscribe_all))))
 
 (defn ^{Test {:groups ["repo"
@@ -288,7 +290,8 @@ Then I see values of repositories ids to be redrawn
           (sleep 2000)
           (verify (not (tasks/has-state? :repo-remove-override "enabled"))))))
     (finally
-      (tasks/ui click :close-repo-dialog)
+      (when (-> (tasks/ui guiexist :repositories-dialog) bool)
+        (tasks/ui click :close-repo-dialog))
       (tasks/unsubscribe_all))))
 
 (defn toggle-checkbox-state
@@ -465,7 +468,8 @@ Then I see values of repositories ids to be redrawn
                  (tasks/has-state? :repo-remove-override "enabled")))
     (assert-and-remove-all-override)
     (finally
-      (tasks/ui click :close-repo-dialog)
+      (when (-> (tasks/ui guiexist :repositories-dialog) bool)
+        (tasks/ui click :close-repo-dialog))
       (tasks/unsubscribe_all))))
 
 (defn ^{Test {:groups ["repo"

--- a/test/rhsm/gui/tests/repo_test.clj
+++ b/test/rhsm/gui/tests/repo_test.clj
@@ -47,3 +47,6 @@
 
 (deftest check_repo_visible-test
   (tests/check_repo_disabled nil))
+
+(deftest check_repo_message_unsubscribed-test
+  (tests/check_repo_message_unsubscribed nil))


### PR DESCRIPTION
- there are exceptions risen from '(finally ...' in our tests.
- the exceptions are caused by (task/ui click ...). It is funny that a code suppose that some dialog window exists - ie. all tests passed. But when some problem occurs (and the dialog window is not available :-) The right exception - AssertionException is hidden by the one risen by not imporant piece of code.

Sweet hunny code.
 