### PR TITLE
gen-class for classification and exception types

### DIFF
--- a/src/rhsm/errors/classification.clj
+++ b/src/rhsm/errors/classification.clj
@@ -32,3 +32,5 @@
           (match :throw-as-skipped (throw+ (SkipException.
                                             (format "Trapped exception: %s" e#)))
                  :re-throw         (throw+ e#))))))
+
+(gen-class)

--- a/src/rhsm/errors/exceptions.clj
+++ b/src/rhsm/errors/exceptions.clj
@@ -22,3 +22,5 @@
   
   Object
   (failure-level [o] :unknown))
+
+(gen-class)


### PR DESCRIPTION
Just (gen-class) in classification.clj and exceptions.clj.
I hope it solves an error 'No implementation of method: :failure-level of protocol: #'rhsm.errors.classification/IFailureClassifier found for class: clojure.lang.PersistentArrayMap'