### PR TITLE
Fix for firstboot enable proxy auth

### DIFF
--- a/src/rhsm/gui/tasks/tasks.clj
+++ b/src/rhsm/gui/tasks/tasks.clj
@@ -1127,3 +1127,12 @@ The function uses an utility 'import' from package 'imagemagick'"
                (RemoteFileTasks/getFile (.getConnection @clientcmd) (.toString out-dir#) name#)
                (log/info (format "A screenshot has been copied as '%s'." (.toString (io/file out-dir# name#)))))
              (throw+)))))
+
+(defmacro try-more
+  [num-of-retries & body]
+  "The macro evalues the body more times when an exception is risen."
+  (if (> (Math/abs num-of-retries) 0)
+    (do `(try+ ~@body
+               (catch Object e#
+                 (try-more ~(dec (Math/abs num-of-retries)) ~@body))))
+    (do `(do ~@body))))

--- a/src/rhsm/gui/tests/firstboot_proxy_tests.clj
+++ b/src/rhsm/gui/tests/firstboot_proxy_tests.clj
@@ -133,7 +133,7 @@
         (tasks/ui click :firstboot-forward))
       ;;(verify (not (bool (tasks/ui guiexist :firstboot-window))))
       ;;(verify (not (tasks/ui showing? :register-system)))
-      (tasks/verify-conf-proxies hostname port username password))
+      (tasks/try-more 3 (tasks/verify-conf-proxies hostname port username password)))
     (finally
       (reset_firstboot)
       (tasks/disableproxy true)

--- a/test/rhsm/gui/tasks/tasks_test.clj
+++ b/test/rhsm/gui/tasks/tasks_test.clj
@@ -37,3 +37,9 @@
   (is (thrown? Exception (tasks/screenshot-on-exception
                           "suffix-of-screenshot"
                           (sl/throw+ "error in common way")))))
+
+(deftest try-more-test
+  (is (thrown? Exception (tasks/try-more 3 (sl/throw+ "some exception")))))
+
+(deftest try-more-01-test
+  (is (= "no exception" (tasks/try-more 3 "no exception"))))

--- a/test/rhsm/gui/tests/firstboot_test.clj
+++ b/test/rhsm/gui/tests/firstboot_test.clj
@@ -4,10 +4,9 @@
         [rhsm.gui.tasks.test-config :only (config
                                            clientcmd)])
   (:require  [clojure.test :refer :all]
-             [rhsm.gui.tests.firstboot_tests :as ftests]
+             [rhsm.gui.tests.firstboot_tests :as tests]
              [rhsm.gui.tasks.tasks :as tasks]
              [rhsm.gui.tasks.tools :as tt]
-             [rhsm.gui.tasks.ui :as ui]
              [rhsm.gui.tasks.test-config :as c]
              [rhsm.runtestng]
              [slingshot.slingshot :as sl]
@@ -20,22 +19,22 @@
 
 (deftest skip-by-rhel-release-test
   (testing "A method raises SkipException is some cases."
-    (is (thrown? SkipException (ftests/skip-by-rhel-release {:family "RHEL5" :variant "Server" :version "5.7"})))
-    (let [[rhel-version-major rhel-version-minor] (ftests/skip-by-rhel-release {:family "RHEL6" :variant "Server" :version "6.8"})]
+    (is (thrown? SkipException (tests/skip-by-rhel-release {:family "RHEL5" :variant "Server" :version "5.7"})))
+    (let [[rhel-version-major rhel-version-minor] (tests/skip-by-rhel-release {:family "RHEL6" :variant "Server" :version "6.8"})]
       (is (= "6" rhel-version-major))
       (is (= "8" rhel-version-minor)))
 
-    (let [[rhel-version-major rhel-version-minor] (ftests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.0"})]
+    (let [[rhel-version-major rhel-version-minor] (tests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.0"})]
       (is (= "7" rhel-version-major))
       (is (= "0" rhel-version-minor)))
 
-    (let [[rhel-version-major rhel-version-minor] (ftests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.1"})]
+    (let [[rhel-version-major rhel-version-minor] (tests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.1"})]
       (is (= "7" rhel-version-major))
       (is (= "1" rhel-version-minor)))
 
-    (ftests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.1"})
-    (is (thrown? SkipException (ftests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.2"})))
-    (is (thrown? SkipException (ftests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.3"})))
-    (is (thrown? SkipException (ftests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.4"})))
-    (is (thrown? SkipException (ftests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.5"})))
-    (is (thrown? SkipException (ftests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.6"})))))
+    (tests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.1"})
+    (is (thrown? SkipException (tests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.2"})))
+    (is (thrown? SkipException (tests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.3"})))
+    (is (thrown? SkipException (tests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.4"})))
+    (is (thrown? SkipException (tests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.5"})))
+    (is (thrown? SkipException (tests/skip-by-rhel-release {:family "RHEL7" :variant "Server" :version "7.6"})))))


### PR DESCRIPTION
- new macro 'try-more'. It catches an exception for 'num' of retries.
- surrounded a verification with this macro in the test 'firstboot_enable_proxy_auth'
