### PR TITLE
Automation of bug 1395684

### DIFF
--- a/src/rhsm/gui/tasks/tasks.clj
+++ b/src/rhsm/gui/tasks/tasks.clj
@@ -44,6 +44,7 @@
                    :no-sla-available #"No service level will cover all installed products"
                    :error-getting-subscription #"Pool is restricted to physical systems"
                    :no-system-name #"You must enter a system name"
+                   :proxy-connection-failed #"Proxy connection failed, please check your settings."
                    :unable-to-connect-server #"Network error, unable to connect to server."})
 
 (defn matching-error

--- a/src/rhsm/gui/tests/proxy_tests.clj
+++ b/src/rhsm/gui/tests/proxy_tests.clj
@@ -348,15 +348,16 @@ Then I should see the message 'Proxy connection failed, please check your settin
                                                 (str ":" (@config :basicauth-proxy-port)))))
   (tasks/ui click :close-proxy)
   (tasks/ui waittillguinotexist :proxy-config-dialog 60)
-  (verify (-> (get-logging @clientcmd
-                           rhsm-log
-                           "error_dialog_when_registering_via_proxy"
-                           nil
-                           (tasks/ui click :register))
-              (.contains "Traceback (most recent call last)")
-              not))
-  (let [thrown-error (try+ (tasks/checkforerror) (catch Object e (:type e)))]
-    (verify (= thrown-error :proxy-connection-failed))))
+  (tasks/screenshot-on-exception
+   (verify (-> (get-logging @clientcmd
+                            rhsm-log
+                            "error_dialog_when_registering_via_proxy"
+                            nil
+                            (tasks/ui click :register))
+               (.contains "Traceback (most recent call last)")
+               not))
+   (let [thrown-error (try+ (tasks/checkforerror) (catch Object e (:type e)))]
+     (verify (= thrown-error :proxy-connection-failed)))))
 
 (defn ^{Test {:groups ["proxy"
                        "tier3"

--- a/src/rhsm/gui/tests/proxy_tests.clj
+++ b/src/rhsm/gui/tests/proxy_tests.clj
@@ -327,7 +327,7 @@ Then I should see a button 'Test connection' being disabled."}}
     and I click on 'Register' button
     and I click on 'I would like to connect via an HTTP Proxy'
 When I click on 'Use Authentication with HTTP Proxy'
- and I leave fields 'user' and 'password' blank
+ and I leave fields 'username' and 'password' blank
  and I click on the button 'Save'
  and I click on the button 'Next' in the 'System Registration' dialog
 Then I should see the message 'Proxy connection failed, please check your settings.'

--- a/src/rhsm/gui/tests/proxy_tests.clj
+++ b/src/rhsm/gui/tests/proxy_tests.clj
@@ -330,8 +330,8 @@ When I click on 'Use Authentication with HTTP Proxy'
  and I leave fields 'user' and 'password' blank
  and I click on the button 'Save'
  and I click on the button 'Next' in the 'System Registration' dialog
-Then I should see an error dialog 'Unable to reach the server'
- and no traceback should appear in a log file."}}
+Then I should see the message 'Proxy connection failed, please check your settings.'
+ and no traceback should appear in the log file."}}
   error_dialog_when_registering_via_proxy
   [_]
   (tasks/restart-app :force-kill? true)
@@ -355,9 +355,8 @@ Then I should see an error dialog 'Unable to reach the server'
                            (tasks/ui click :register))
               (.contains "Traceback (most recent call last)")
               not))
-  ;;(tasks/ui click :register)
   (let [thrown-error (try+ (tasks/checkforerror) (catch Object e (:type e)))]
-    (verify (= thrown-error :network-error))))
+    (verify (= thrown-error :proxy-connection-failed))))
 
 (defn ^{Test {:groups ["proxy"
                        "tier3"

--- a/src/rhsm/gui/tests/proxy_tests.clj
+++ b/src/rhsm/gui/tests/proxy_tests.clj
@@ -320,6 +320,46 @@ Then I should see a button 'Test connection' being disabled."}}
   (verify (not (tasks/ui hasstate :test-connection "enabled"))))
 
 (defn ^{Test {:groups ["proxy"
+                       "tier2"
+                       "blockedByBug-1395684"]
+              :description "Given a system is unregistered
+    and I run subscription-manager-gui
+    and I click on 'Register' button
+    and I click on 'I would like to connect via an HTTP Proxy'
+When I click on 'Use Authentication with HTTP Proxy'
+ and I leave fields 'user' and 'password' blank
+ and I click on the button 'Save'
+ and I click on the button 'Next' in the 'System Registration' dialog
+Then I should see an error dialog 'Unable to reach the server'
+ and no traceback should appear in a log file."}}
+  error_dialog_when_registering_via_proxy
+  [_]
+  (tasks/restart-app :force-kill? true)
+  (tasks/disableproxy)
+  (try+ (tasks/unregister)
+        (catch [:type :not-registered] _))
+  (tasks/ui click :register-system)
+  (tasks/ui click :configure-proxy)
+  (tasks/ui waittillwindowexist :proxy-config-dialog 60)
+  (tasks/ui check :proxy-checkbox)
+  (tasks/ui uncheck :authentication-checkbox)
+  (tasks/ui settextvalue :proxy-location (str (@config :basicauth-proxy-hostname)
+                                              (when (@config :basicauth-proxy-port)
+                                                (str ":" (@config :basicauth-proxy-port)))))
+  (tasks/ui click :close-proxy)
+  (tasks/ui waittillguinotexist :proxy-config-dialog 60)
+  (verify (-> (get-logging @clientcmd
+                           rhsm-log
+                           "error_dialog_when_registering_via_proxy"
+                           nil
+                           (tasks/ui click :register))
+              (.contains "Traceback (most recent call last)")
+              not))
+  ;;(tasks/ui click :register)
+  (let [thrown-error (try+ (tasks/checkforerror) (catch Object e (:type e)))]
+    (verify (= thrown-error :network-error))))
+
+(defn ^{Test {:groups ["proxy"
                        "tier3"
                        "blockedByBug-920551"]}}
   test_invalid_proxy_restart

--- a/test/rhsm/gui/tests/proxy_test.clj
+++ b/test/rhsm/gui/tests/proxy_test.clj
@@ -30,3 +30,6 @@
         (tests/test_connection_button_is_blocked_before_all_fields_are_set nil)
         (is (thrown? java.lang.AssertionError
                      (tests/test_connection_button_is_blocked_before_all_fields_are_set nil))))))
+
+(deftest error_dialog_when_registering_via_proxy-test
+  (tests/error_dialog_when_registering_via_proxy nil))

--- a/test/rhsm/gui/tests/proxy_test.clj
+++ b/test/rhsm/gui/tests/proxy_test.clj
@@ -8,7 +8,7 @@
   (:use gnome.ldtp
         [com.redhat.qe.verify :only (verify)]))
 
-;; ;; initialization of our testware
+;; initialization of our testware
 (use-fixtures :once (fn [f]
                       (base/startup nil)
                       (tests/setup nil)


### PR DESCRIPTION
automated use case:
```gherkin
Given a system is unregistered
    and I run subscription-manager-gui
    and I click on 'Register' button
    and I click on 'I would like to connect via an HTTP Proxy'
When I click on 'Use Authentication with HTTP Proxy'
 and I leave fields 'user' and 'password' blank
 and I click on the button 'Save'
 and I click on the button 'Next' in the 'System Registration' dialog
Then I should see the message 'Proxy connection failed, please check your settings.'
 and no traceback should appear in the log file.
```
