### PR TITLE
Start app raises skip exception instead of test failure

### DIFF
--- a/src/rhsm/gui/tests/firstboot_proxy_tests.clj
+++ b/src/rhsm/gui/tests/firstboot_proxy_tests.clj
@@ -86,15 +86,15 @@
       (skip-if-bz-open "922806")
       (skip-if-bz-open "1016643" (= rhel-version-major "7"))
       (when (= rhel-version-major "7") (base/startup nil)))
-    (when-not (= 0 (-> (run-command (format "which %s" (@config :firstboot-binary-path))) :exitcode))
-      (throw (SkipException. "No firstboot binary found")))
+    (assert (= 0 (-> (run-command (format "which %s" (@config :firstboot-binary-path))) :exitcode))
+            "No firstboot binary found" )
     ;; new rhsm and classic have to be totally clean for this to run
     (run-command "subscription-manager clean")
     (let [sysidpath "/etc/sysconfig/rhn/systemid"]
       (run-command (str "[ -f " sysidpath " ] && rm " sysidpath)))
     (catch Exception e
       (reset! (skip-groups :firstboot) true)
-      (throw e))))
+      (throw (SkipException. (str "some problem in setup for firstboot_proxy_tests. Was: " (.toString e)))))))
 
 (defn ^{AfterClass {:groups ["cleanup"]
                     :alwaysRun true}}

--- a/src/rhsm/gui/tests/firstboot_proxy_tests.clj
+++ b/src/rhsm/gui/tests/firstboot_proxy_tests.clj
@@ -14,6 +14,7 @@
             [rhsm.gui.tasks.tasks :as tasks]
             [rhsm.gui.tests.base :as base]
             [rhsm.gui.tests.firstboot_tests :as ftests]
+            [clojure.java.io :as io]
             rhsm.gui.tasks.ui)
   (:import [org.testng.annotations
             AfterClass
@@ -85,6 +86,8 @@
       (skip-if-bz-open "922806")
       (skip-if-bz-open "1016643" (= rhel-version-major "7"))
       (when (= rhel-version-major "7") (base/startup nil)))
+    (when-not (= 0 (-> (run-command (format "which %s" (@config :firstboot-binary-path))) :exitcode))
+      (throw (SkipException. "No firstboot binary found")))
     ;; new rhsm and classic have to be totally clean for this to run
     (run-command "subscription-manager clean")
     (let [sysidpath "/etc/sysconfig/rhn/systemid"]

--- a/src/rhsm/gui/tests/firstboot_tests.clj
+++ b/src/rhsm/gui/tests/firstboot_tests.clj
@@ -89,15 +89,15 @@
       (skip-if-bz-open "922806")
       (skip-if-bz-open "1016643" (= rhel-version-major "7"))
       (when (= rhel-version-major "7") (base/startup nil)))
-    (when-not (= 0 (-> (run-command (format "which %s" (@config :firstboot-binary-path))) :exitcode))
-      (throw (SkipException. "No firstboot binary found")))
+    (assert (= 1 (-> (run-command (format "which %s" (@config :firstboot-binary-path))) :exitcode))
+            "No firstboot binary found")
     ;; new rhsm and classic have to be totally clean for this to run
     (run-command "subscription-manager clean")
     (let [sysidpath "/etc/sysconfig/rhn/systemid"]
       (run-command (str "[ -f " sysidpath " ] && rm " sysidpath)))
     (catch Exception e
       (reset! (skip-groups :firstboot) true)
-      (throw e))))
+      (throw (SkipException. (str "some problem in setup for firstboot_tests. Was: " (.toString e)))))))
 
 (defn ^{AfterClass {:groups ["cleanup"]
                     :alwaysRun true}}

--- a/src/rhsm/gui/tests/firstboot_tests.clj
+++ b/src/rhsm/gui/tests/firstboot_tests.clj
@@ -12,7 +12,8 @@
             [rhsm.gui.tasks.tasks :as tasks]
             [rhsm.gui.tests.base :as base]
             [clojure.core.match :refer [match]]
-            rhsm.gui.tasks.ui)
+            rhsm.gui.tasks.ui
+            [clojure.java.io :as io])
   (:import [org.testng.annotations
             AfterClass
             BeforeClass
@@ -88,6 +89,8 @@
       (skip-if-bz-open "922806")
       (skip-if-bz-open "1016643" (= rhel-version-major "7"))
       (when (= rhel-version-major "7") (base/startup nil)))
+    (when-not (= 0 (-> (run-command (format "which %s" (@config :firstboot-binary-path))) :exitcode))
+      (throw (SkipException. "No firstboot binary found")))
     ;; new rhsm and classic have to be totally clean for this to run
     (run-command "subscription-manager clean")
     (let [sysidpath "/etc/sysconfig/rhn/systemid"]

--- a/test/rhsm/gui/tests/base_test.clj
+++ b/test/rhsm/gui/tests/base_test.clj
@@ -14,3 +14,6 @@
 
 (deftest open-connection-to-candlepin-test
   (base/open-connection-to-candlepin))
+
+(deftest firstboot-binary-check-test
+  (is (= 0 (-> (tools/run-command (format "which %s" (@c/config :firstboot-binary-path))) :exitcode))))

--- a/test/rhsm/gui/tests/firstboot_test.clj
+++ b/test/rhsm/gui/tests/firstboot_test.clj
@@ -15,7 +15,10 @@
   (:import   org.testng.SkipException))
 
 ;; ;; initialization of our testware
-(use-fixtures :once (fn [f] (base/startup nil)(f)))
+(use-fixtures :once (fn [f]
+                      (base/startup nil)
+                      (tests/firstboot_init nil)
+                      (f)))
 
 (deftest skip-by-rhel-release-test
   (testing "A method raises SkipException is some cases."


### PR DESCRIPTION
It is in startup functions for 'firstboot-proxy-tests' and 'firstboot-tests'.
If firstboot does not exist there are tests that informs about that failure. 
Failure in the startup functions is caused by slow response of a test environment.