### PR TITLE
Fix ifailureclassifier implementation error

### DIFF
--- a/src/rhsm/gui/tests/register_tests.clj
+++ b/src/rhsm/gui/tests/register_tests.clj
@@ -16,6 +16,7 @@
             [rhsm.gui.tests.base :as base]
             [clojure.tools.logging :as log]
             [rhsm.errors.classification :as erc]
+            [rhsm.errors.exceptions :as exc]
             [rhsm.gui.tasks.candlepin-tasks :as ctasks])
   (:import [org.testng.annotations
             Test

--- a/src/rhsm/gui/tests/repo_tests.clj
+++ b/src/rhsm/gui/tests/repo_tests.clj
@@ -20,6 +20,7 @@
             [rhsm.gui.tasks.candlepin-tasks :as ctasks]
             [clojure.core.match :as match]
             [rhsm.errors.classification :as erc]
+            [rhsm.errors.exceptions :as exc]
             rhsm.gui.tasks.ui)
   (:import [org.testng.annotations
             BeforeClass

--- a/test/rhsm/errors/classification_test.clj
+++ b/test/rhsm/errors/classification_test.clj
@@ -2,6 +2,7 @@
   (:use [slingshot.slingshot :only (try+ throw+)]
         [com.redhat.qe.verify :only (verify)])
   (:require [rhsm.errors.classification :as sut]
+            [rhsm.errors.exceptions :as exc]
             [clojure.test :refer [deftest is]])
   (:import org.testng.SkipException))
 

--- a/test/rhsm/gui/tests/register_test.clj
+++ b/test/rhsm/gui/tests/register_test.clj
@@ -39,17 +39,20 @@
 (deftest a-part-of-suite-08-test
   (tests/register_bad_credentials nil [(@c/config :username) (@c/config :password) :system-name-input ""] :no-system-name))
 
-(deftest simple-register-test
+(deftest simple-register-01-test
   (tests/simple_register nil "testuser1" "password" nil))
 
-(deftest simple-register-test
+(deftest simple-register-02-test
   (tests/simple_register nil "testuser2" "password" "Admin Owner"))
 
-(deftest simple-register-test
+(deftest simple-register-03-test
   (tests/simple_register nil "testuser1" "password" "Admin Owner"))
 
-(deftest simple-register-test
+(deftest simple-register-04-test
   (tests/simple_register nil "testuser1" "password" "Snow White"))
+
+(deftest simple-register-05-test
+  (tests/simple_register nil "stage_auto_testuser1   " "redhat" nil))
 
 (deftest check_traceback_unregister-test
   (tests/check_traceback_unregister nil))


### PR DESCRIPTION
It is necessary to import a code with implementation of IFailureClassifier protocol everywhere the implementation can be used.