### PR TITLE
Rewrite of failure classification

### DIFF
--- a/src/rhsm/errors/implementations.clj
+++ b/src/rhsm/errors/implementations.clj
@@ -1,10 +1,9 @@
-(ns rhsm.errors.exceptions
-  (:require [rhsm.errors.classification :as classification]
+(ns rhsm.errors.implementations
+  (:require [rhsm.errors.protocols :as protocols]
             [clojure.core.match :refer [match]])
-
   (:import org.testng.SkipException))
 
-(extend-protocol classification/IFailureClassifier
+(extend-protocol protocols/IFailureClassifier
   SkipException
   (failure-level [e] :skip-exception)
 

--- a/src/rhsm/errors/protocols.clj
+++ b/src/rhsm/errors/protocols.clj
@@ -1,0 +1,35 @@
+(ns rhsm.errors.protocols
+  (:use [slingshot.slingshot :only (try+ throw+)]
+        [clojure.core.match :only (match)])
+  (:require [clojure.tools.logging :as log]))
+
+(defprotocol IFailureClassifier
+  "Methods related to classifying of exceptions mainly.
+  It is important to distinguish errors and exceptions
+  from TestNG report results perspective."
+  (failure-level [a]
+    "returns:
+      -  :testware-problem
+      -  :verification-failure
+      -  :skip-exception
+      -  :network-error
+      -  :unknown-exception
+      -  :unknown"))
+
+;; (defmacro normalize-exception-types
+;;   "This macro catches an exception
+;;   and tries to find out 'failure-level' of the exception.
+;;   After that it raises the proper exception when 'failure-level'
+;;   requires so."
+;;   [& body]
+;;   `(try+
+;;     ~@body
+;;     (catch Object e#
+;;       (-> (failure-level e#)
+;;           (match :verification-failure :re-throw
+;;                  :network-error        :throw-as-skipped
+;;                  :else                 :no-throw)
+;;           (match :throw-as-skipped (throw+ (SkipException.
+;;                                             (format "Trapped exception: %s" e#)))
+;;                  :re-throw         (throw+ e#))))))
+

--- a/src/rhsm/errors/utils.clj
+++ b/src/rhsm/errors/utils.clj
@@ -1,20 +1,8 @@
-(ns rhsm.errors.classification
+(ns rhsm.errors.utils
   (:use [slingshot.slingshot :only (try+ throw+)]
+        [rhsm.errors.protocols :as protocols]
         [clojure.core.match :only (match)])
   (:require [clojure.tools.logging :as log]))
-
-(defprotocol IFailureClassifier
-  "Methods related to classifying of exceptions mainly.
-  It is important to distinguish errors and exceptions
-  from TestNG report results perspective."
-  (failure-level [a]
-    "returns:
-      -  :testware-problem
-      -  :verification-failure
-      -  :skip-exception
-      -  :network-error
-      -  :unknown-exception
-      -  :unknown"))
 
 (defmacro normalize-exception-types
   "This macro catches an exception
@@ -25,7 +13,7 @@
   `(try+
     ~@body
     (catch Object e#
-      (-> (failure-level e#)
+      (-> (protocols/failure-level e#)
           (match :verification-failure :re-throw
                  :network-error        :throw-as-skipped
                  :else                 :no-throw)

--- a/src/rhsm/gui/tests/register_tests.clj
+++ b/src/rhsm/gui/tests/register_tests.clj
@@ -15,8 +15,7 @@
             [rhsm.gui.tasks.ui :as ui]
             [rhsm.gui.tests.base :as base]
             [clojure.tools.logging :as log]
-            [rhsm.errors.classification :as erc]
-            [rhsm.errors.exceptions :as exc]
+            [rhsm.errors.utils :refer [normalize-exception-types]]
             [rhsm.gui.tasks.candlepin-tasks :as ctasks])
   (:import [org.testng.annotations
             Test
@@ -57,7 +56,7 @@
   simple_register
   "Simple register with known username, password and owner."
   [_ user pass owner]
-  (erc/normalize-exception-types
+  (normalize-exception-types
    (try+
     (if owner
       (tasks/register user pass :owner owner)
@@ -117,7 +116,7 @@
   unregister
   "Simple unregister."
   [_]
-  (erc/normalize-exception-types
+  (normalize-exception-types
    (try+ (tasks/register (@config :username) (@config :password))
          (catch
              [:type :already-registered]

--- a/src/rhsm/gui/tests/repo_tests.clj
+++ b/src/rhsm/gui/tests/repo_tests.clj
@@ -19,8 +19,7 @@
             [rhsm.gui.tests.base :as base]
             [rhsm.gui.tasks.candlepin-tasks :as ctasks]
             [clojure.core.match :as match]
-            [rhsm.errors.classification :as erc]
-            [rhsm.errors.exceptions :as exc]
+            [rhsm.errors.utils :refer [normalize-exception-types]]
             rhsm.gui.tasks.ui)
   (:import [org.testng.annotations
             BeforeClass
@@ -177,7 +176,7 @@
   "This tests for default static message in repository dialog when unsubscribed"
   [_]
   (try
-    (erc/normalize-exception-types
+    (normalize-exception-types
      (if (tasks/ui showing? :register-system)
        (tasks/register-with-creds))
      (assert-and-open-repo-dialog)

--- a/test/rhsm/errors/classification_test.clj
+++ b/test/rhsm/errors/classification_test.clj
@@ -1,27 +1,28 @@
 (ns rhsm.errors.classification-test
   (:use [slingshot.slingshot :only (try+ throw+)]
         [com.redhat.qe.verify :only (verify)])
-  (:require [rhsm.errors.classification :as sut]
-            [rhsm.errors.exceptions :as exc]
+  (:require [rhsm.errors.utils :as sut]
+            [rhsm.errors.protocols :as prot]
+            [rhsm.errors.implementations :as impl]
             [clojure.test :refer [deftest is]])
   (:import org.testng.SkipException))
 
 (deftest skip-exception-failure-level-test
-  (is (= :skip-exception (sut/failure-level (new SkipException "some exception")))))
+  (is (= :skip-exception (prot/failure-level (new SkipException "some exception")))))
 
 (deftest exception-test
-  (is (= :unknown-exception (sut/failure-level (new Exception "some exception in general manner")))))
+  (is (= :unknown-exception (prot/failure-level (new Exception "some exception in general manner")))))
 
 (deftest unknown-string-test
-  (is (= :unknown (sut/failure-level "unknown string"))))
+  (is (= :unknown (prot/failure-level "unknown string"))))
 
 (deftest unknown-integer-test
-  (is (= :unknown (sut/failure-level (Integer. 10)))))
+  (is (= :unknown (prot/failure-level (Integer. 10)))))
 
 (deftest verification-exception-test
   (let [e (try+ (verify false)
                 (catch Object e e))]
-    (is (= :verification-failure (sut/failure-level e)))))
+    (is (= :verification-failure (prot/failure-level e)))))
 
 (deftest network-candlepin-connection-error-test
   (let [e (try+ (throw+  {:type :network-error
@@ -30,7 +31,7 @@
                           :cancel :some-object-reference})
                 (catch Object e
                   e))]
-    (is (= :network-error (sut/failure-level e)))))
+    (is (= :network-error (prot/failure-level e)))))
 
 (deftest exception-re-risen-test
   (is (thrown? SkipException


### PR DESCRIPTION
There was interesting problem such 'No method found for implementation IFailureClassifier for Exception. It was interesting that 'lein quickie' does not raise this error. Just 'lein testng' does that.

It was caused by that clojure does not initialize protocol for that. 
It is necessary to import a code with implementation of the protocol at the beginning of code execution. It is my early understanding of that story.

So I have splitted the files for this story into:
- errors/protocols.clj
- errors/implementations.clj
- errors/utils.clj

I am getting the right habbit with naming of source files and splitting into the right parts.