### PR TITLE
Fixed  VerifyNewContentAvailability_Test()

### DIFF
--- a/src/rhsm/cli/tests/BugzillaTests.java
+++ b/src/rhsm/cli/tests/BugzillaTests.java
@@ -4739,7 +4739,7 @@ public class BugzillaTests extends SubscriptionManagerCLITestScript {
 				null, null);
 		// in test data verifying that already enabled repos are not available
 		List<Repo> listEnabledRepos = Repo.parse(sshCommandResult.getStdout());
-		Assert.assertTrue(listEnabledRepos.isEmpty(), "No attached subscriptions provides a enabled repos .");
+		//Assert.assertTrue(listEnabledRepos.isEmpty(), "No attached subscriptions provides a enabled repos .");
 
 		// Create a new content "Newcontent_foo"
 		requestBody = CandlepinTasks.createContentRequestBody("Newcontent_foo", contentId, "Newcontent_foo", "yum",


### PR DESCRIPTION
Hi John,

Please review , 
fix : 
Removed the assertion to check if there are already any enabled repos, because i think regardless of the the presently enabled repos , newly added content should be available. So I have just commented out the Assertion .

thanks,
Rehana