### PR TITLE
fixed a problem with a test 'verify_update_facts'

### DIFF
--- a/test/rhsm/testng_test.clj
+++ b/test/rhsm/testng_test.clj
@@ -20,6 +20,9 @@
 (deftest tier1-cli-suite
   (TestNG/main (into-array String ["suites/sm-cli-tier1-testng-suite.xml"])))
 
+(deftest tier1-gui-suite
+  (TestNG/main (into-array String ["suites/sm-gui-tier1-testng-suite.xml"])))
+
 (deftest tier1-cli-one-suite
   (TestNG/main (into-array String ["suites/sm-cli-one-testng-suite.xml"])))
 


### PR DESCRIPTION
It was caused such that there was a value of a combo 'release' from previous test at display. And the value prohibited ldtp to read actual dialog. The actual dialog was 'facts'.