### PR TITLE
Fix a test check unlimited quantities

### DIFF
--- a/src/rhsm/gui/tests/subscribe_tests.clj
+++ b/src/rhsm/gui/tests/subscribe_tests.clj
@@ -62,6 +62,7 @@
   (try
     ;;(if (= "RHEL7" (get-release)) (base/startup nil))
     (tasks/unsubscribe_all)
+    (run-command "subscription-manager unregister")
     (tasks/register-with-creds)
     (reset! servicelist (ctasks/build-service-map :all? true))
     (reset! subs-contractlist (ctasks/build-subscription-product-map :all? true))

--- a/test/rhsm/gui/tests/subscribe_test.clj
+++ b/test/rhsm/gui/tests/subscribe_test.clj
@@ -110,3 +110,8 @@
 
 (deftest changes_when_consumer_is_purged-test
   (tests/changes_when_consumer_is_purged nil))
+
+(deftest check_unlimited_quantities-test
+  (let [pools #spy/d (tests/get_unlimited_pools nil :debug true)]
+    (doseq [pool pools]
+      (tests/check_unlimited_quantities nil (first pool) (second pool)))))

--- a/test/rhsm/testng_test.clj
+++ b/test/rhsm/testng_test.clj
@@ -6,10 +6,10 @@
 ;;
 ;; this test is run this way:
 ;;
-;;       lein test rhsm.gui.tests.setup-test
+;;       lein test rhsm.testng-test
 ;; or
 ;;
-;;     lein test :only rhsm.gui.tests.setup-test/tier1-all-suites-test
+;;     lein test :only rhsm.testng-test/tier1-all-suites
 ;;
 ;; this test is to run the whole testng machinery with our tests
 ;;


### PR DESCRIPTION
a little improvement for subscribe tests. BeforeClass method raised an error 'a system is already registered'. 