### PR TITLE
Skallesh

### DIFF
--- a/src/rhsm/cli/tasks/CandlepinTasks.java
+++ b/src/rhsm/cli/tasks/CandlepinTasks.java
@@ -4433,7 +4433,7 @@ schema generation failed
 		return httpResponse;
 	}
 	
-	public static String updateSubscriptionDatesAndRefreshPoolsUsingRESTfulAPIUsingPoolId(String authenticator,
+	/*public static String updateSubscriptionDatesAndRefreshPoolsUsingRESTfulAPIUsingPoolId(String authenticator,
 			String password, String url, String poolId, Calendar startCalendar, Calendar endCalendar) throws JSONException, Exception {
 			String httpResponse=null;
 // THIS IS EFFECTIVELY A DUPLICATE IMPLEMENTATION OF updateSubscriptionPoolDatesUsingRESTfulAPI(...)
@@ -4460,7 +4460,7 @@ schema generation failed
 				
 				
 				// update the subscription using poolid
-				JSONObject jsonStatus = new JSONObject(CandlepinTasks.getResourceUsingRESTfulAPI(/*authenticator*/null,/*password*/null,url,"/status"));
+				JSONObject jsonStatus = new JSONObject(CandlepinTasks.getResourceUsingRESTfulAPI(authenticatornull,passwordnull,url,"/status"));
 				if (SubscriptionManagerTasks.isVersion(jsonStatus.getString("version"), ">=", "2.0.0"))
 					 httpResponse = CandlepinTasks.putResourceUsingRESTfulAPI(authenticator,password,url,"/owners/"+jsonSubscription.getJSONObject("owner").getString("key")+"/pools",requestBody);
 				else
@@ -4472,7 +4472,7 @@ schema generation failed
 				JSONObject jobDetail = CandlepinTasks.refreshPoolsUsingRESTfulAPI(authenticator,password,url,jsonOwner.getString("key"));
 				jobDetail = CandlepinTasks.waitForJobDetailStateUsingRESTfulAPI(authenticator,password,url,jobDetail,"FINISHED", 5*1000, 1);
 				return httpResponse;		
-	}
+	}*/
 
 	/**
 	 * This is a replacement for updateSubscriptionDatesAndRefreshPoolsUsingRESTfulAPI(...) after candlepin commit 9c448315c843c0a20167236af7591359d895613a Discontinue ambiguous subscription resources in sharing world

--- a/src/rhsm/cli/tests/GoldenTicketTests.java
+++ b/src/rhsm/cli/tests/GoldenTicketTests.java
@@ -199,7 +199,7 @@ public class GoldenTicketTests extends SubscriptionManagerCLITestScript {
 			posneg= PosNeg.POSITIVE, importance= DefTypes.Importance.HIGH, automation= DefTypes.Automation.AUTOMATED,
 			tags= "Tier3")
 	@Test(	description = "Verify golden ticket entitlement is granted when system is registered using an activationkey belonging to an org that has a contentAccessMode set",
-			groups = {"Tier3Tests","testGoldenTicketIsGrantedWhenRegisteredUsingActivationKey"},
+			groups = {"Tier3Tests","testGoldenTicketIsGrantedWhenRegisteredUsingActivationKey","blockedByBug-1564453"},
 			enabled = true)
     public void testGoldenTicketIsGrantedWhenRegisteredUsingActivationKey() throws JSONException, Exception {
 

--- a/src/rhsm/cli/tests/GoldenTicketTests.java
+++ b/src/rhsm/cli/tests/GoldenTicketTests.java
@@ -70,6 +70,7 @@ public class GoldenTicketTests extends SubscriptionManagerCLITestScript {
 			groups = {"Tier3Tests","blockedByBug-1425438"},
 			enabled = true)
     public void testGoldenTicketFunctionality() throws Exception {
+	clienttasks.updateConfFileParameter(clienttasks.rhsmConfFile, "manage_repos", "1");
 
 	CandlepinTasks.setAttributeForOrg(sm_serverAdminUsername, sm_serverAdminPassword, sm_serverUrl, org,
 		attributeName, attributeValue);
@@ -269,7 +270,8 @@ public class GoldenTicketTests extends SubscriptionManagerCLITestScript {
 			groups = {"Tier3Tests","blockedByBug-1448855","testRevokingContentAccessModeOnOwnerRemovesEntitlement" },
 			enabled = true)
     public void testRevokingContentAccessModeOnOwnerRemovesEntitlement() throws Exception {
-
+	
+	clienttasks.updateConfFileParameter(clienttasks.rhsmConfFile, "manage_repos", "1");
 	CandlepinTasks.setAttributeForOrg(sm_serverAdminUsername, sm_serverAdminPassword, sm_serverUrl, org,
 		attributeName, attributeValue);
 	clienttasks.register(sm_clientUsername, sm_clientPassword, org, null, null, null, null, null, null, null,

--- a/src/rhsm/cli/tests/ServiceLevelTests.java
+++ b/src/rhsm/cli/tests/ServiceLevelTests.java
@@ -485,6 +485,9 @@ public class ServiceLevelTests extends SubscriptionManagerCLITestScript {
 		msg = String.format("Service level %s is not available to consumers of organization %s.",unavailableServiceLevel,sm_clientOrg);	// valid before bug fix 864508 - Service level {0} is not available to consumers....
 		msg = String.format("Service level '%s' is not available to consumers of organization %s.",unavailableServiceLevel,sm_clientOrg);
 		if (!clienttasks.workaroundForBug876764(sm_serverType)) msg = String.format("Service level '%s' is not available to units of organization %s.",unavailableServiceLevel,sm_clientOrg);
+		if (SubscriptionManagerTasks.isVersion(servertasks.statusVersion, ">=", "2.3.1-1")) {	// commit 0d5fefcfa8c1c2485921d2dee6633879b1e06931 Correct incorrect punctuation in user messages
+			msg = String.format("Service level \"%s\" is not available to units of organization %s.",unavailableServiceLevel,sm_clientOrg);
+		}
 		Integer expectedExitCode = new Integer(255);
 		if (clienttasks.isPackageVersion("subscription-manager",">=","1.13.8-1")) expectedExitCode = new Integer(70);	// EX_SOFTWARE	// post commit df95529a5edd0be456b3528b74344be283c4d258 bug 1119688
 		if (clienttasks.isPackageVersion("subscription-manager",">=","1.15.9-5")) expectedExitCode = new Integer(1);	// post RHEL7.2 commit 84340a0acda9f070e3e0b733e4335059b5dc204e bug 1221273
@@ -641,7 +644,11 @@ public class ServiceLevelTests extends SubscriptionManagerCLITestScript {
 		String expectedStderr = "";
 		String expectedStdout = "Cannot set a service level for a consumer that is not available to its organization.";
 		expectedStdout = String.format("Service level %s is not available to consumers of organization %s.","FOO",sm_clientOrg);	// valid before bug fix 864508
-		expectedStdout = String.format("Service level '%s' is not available to consumers of organization %s.","FOO",sm_clientOrg);	// valid before bug fix 864508
+		expectedStdout = String.format("Service level '%s' is not available to consumers of organization %s.","FOO",sm_clientOrg);// valid before bug fix 864508
+		if (SubscriptionManagerTasks.isVersion(servertasks.statusVersion, ">=", "2.3.1-1")) {	// commit 0d5fefcfa8c1c2485921d2dee6633879b1e06931 Correct incorrect punctuation in user messages
+			expectedStdout = String.format("Service level \"%s\" is not available to consumers of organization %s.","FOO",sm_clientOrg);// valid before bug fix 864508
+
+		}
 		if (!clienttasks.workaroundForBug876764(sm_serverType)) expectedStdout = String.format("Service level '%s' is not available to units of organization %s.","FOO",sm_clientOrg);
 		if (clienttasks.isPackageVersion("subscription-manager",">=","1.13.8-1")) expectedExitCode = new Integer(70);	// EX_SOFTWARE	// post commit df95529a5edd0be456b3528b74344be283c4d258 bug 1119688
 		if (clienttasks.isPackageVersion("subscription-manager",">=","1.13.9-1")) {String swap=expectedStderr; expectedStderr=expectedStdout; expectedStdout=swap;}	// post commit a695ef2d1da882c5f851fde90a24f957b70a63ad
@@ -1025,6 +1032,10 @@ public class ServiceLevelTests extends SubscriptionManagerCLITestScript {
 		SSHCommandResult result = clienttasks.service_level_(null, null, unavailableSericeLevel, null, null, null, null, null, null, null, null, null, null);
 		String expectedStderr = String.format("Service level %s is not available to consumers of organization %s.",unavailableSericeLevel,org); 	// valid before bug fix 864508
 		expectedStderr = String.format("Service level '%s' is not available to consumers of organization %s.",unavailableSericeLevel,org);
+		if (SubscriptionManagerTasks.isVersion(servertasks.statusVersion, ">=", "2.3.1-1")) {	// commit 0d5fefcfa8c1c2485921d2dee6633879b1e06931 Correct incorrect punctuation in user messages
+			expectedStderr = String.format("Service level \"%s\" is not available to consumers of organization %s.",unavailableSericeLevel,org);
+
+		}
 		if (!clienttasks.workaroundForBug876764(sm_serverType)) expectedStderr = String.format("Service level '%s' is not available to units of organization %s.",unavailableSericeLevel,org);
 		
 		Integer expectedExitCode = new Integer(255);
@@ -1057,7 +1068,9 @@ public class ServiceLevelTests extends SubscriptionManagerCLITestScript {
 		String expectedStderr = String.format("Service level %s is not available to consumers of organization admin.",exemptServiceLevel);	// valid before bug fix 864508
 		expectedStderr = String.format("Service level '%s' is not available to consumers of organization admin.",exemptServiceLevel);
 		if (!clienttasks.workaroundForBug876764(sm_serverType)) expectedStderr = String.format("Service level '%s' is not available to units of organization admin.",exemptServiceLevel);
-
+		if (SubscriptionManagerTasks.isVersion(servertasks.statusVersion, ">=", "2.3.1-1")) {	// commit 0d5fefcfa8c1c2485921d2dee6633879b1e06931 Correct incorrect punctuation in user messages
+			expectedStderr = String.format("Service level \"%s\" is not available to units of organization admin.",exemptServiceLevel);
+		}
 		Integer expectedExitCode = new Integer(255);
 		if (clienttasks.isPackageVersion("subscription-manager",">=","1.13.8-1")) expectedExitCode = new Integer(70);	// EX_SOFTWARE	// post commit df95529a5edd0be456b3528b74344be283c4d258 bug 1119688
 		Assert.assertEquals(result.getExitCode(), expectedExitCode, "ExitCode from service-level --set with exempt serviceLevel");


### PR DESCRIPTION
Have fixed quotes issues with servicelevel tests and failing golden ticket tests
I see that you have added a new method  "updateSubscriptionPoolDatesUsingRESTfulAPI" , so I have added block comment for "updateSubscriptionDatesAndRefreshPoolsUsingRESTfulAPIUsingPoolId" method. which now is a duplicate implementation of updateSubscriptionPoolDatesUsingRESTfulAPI. I am thinking of removing the method from the file instead of adding block comment , if you agree? 