### PR TITLE
blocking the test by bug 1570558

### DIFF
--- a/src/rhsm/cli/tests/ProxyTests.java
+++ b/src/rhsm/cli/tests/ProxyTests.java
@@ -759,7 +759,7 @@ public class ProxyTests extends SubscriptionManagerCLITestScript {
 			posneg= PosNeg.POSITIVE, importance= DefTypes.Importance.HIGH, automation= DefTypes.Automation.AUTOMATED,
 			tags= "Tier3")
 	@Test(	description="subscription-manager : auto-heal using a proxy server after setting rhsm.config parameters (Positive and Negative Variations)",
-			groups={"Tier3Tests"},
+			groups={"Tier3Tests","blockedByBug-1570558"},
 			dataProvider="getAutoHealAttemptsUsingProxyServerViaRhsmConfigData",
 			enabled=true)
 	//@ImplementsNitrateTest(caseId=)	


### PR DESCRIPTION
Activationkey tests worked fine after redeploying the candlepin, so didnot touch them , will wait for one more tier3 run .
Proxy tests were failing due to this bug 1570558,so logged and blocked the test with that bug 